### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,7 @@ author=Andrey Shertsinger
 maintainer=Andrey Shertsinger <andrey@shertsinger.ru>
 sentence=Receive Modbus command over Serial and send it to RF24Network. Answer from RF24Network resend back to Serial.
 paragraph=
+category=Communication
 url=http://www.arduino.cc/en/Reference/SPI
 architectures=avr
 


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library ModbusRtu over RF24Network is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
